### PR TITLE
Fluent builder interfaces for ironic and inspector mocks

### DIFF
--- a/pkg/provisioner/ironic/ready_test.go
+++ b/pkg/provisioner/ironic/ready_test.go
@@ -15,9 +15,28 @@ func buildServer(t *testing.T, name string, v1 string, drivers string) *testserv
 		Response("/v1/drivers", drivers)
 }
 
-func TestProvisionerIsReady(t *testing.T) {
+type ironicMock struct {
+	*testserver.MockServer
+}
 
-	driverResponse := `
+func newIronicMock(t *testing.T) *ironicMock {
+	return &ironicMock{
+		testserver.New(t, "ironic"),
+	}
+}
+
+func (i *ironicMock) ready() *ironicMock {
+	i.Response("/v1", "{}")
+	return i
+}
+
+func (i *ironicMock) notReady(errorCode int) *ironicMock {
+	i.ErrorResponse("/v1", errorCode)
+	return i
+}
+
+func (i *ironicMock) addDrivers() *ironicMock {
+	i.Response("/v1/drivers", `
 	{
 		"drivers": [{
 			"hosts": [
@@ -36,12 +55,36 @@ func TestProvisionerIsReady(t *testing.T) {
 			"name": "fake-hardware"
 		}]
 	}
-	`
+	`)
+	return i
+}
+
+type inspectorMock struct {
+	*testserver.MockServer
+}
+
+func newInspectorMock(t *testing.T) *inspectorMock {
+	return &inspectorMock{
+		testserver.New(t, "inspector"),
+	}
+}
+
+func (i *inspectorMock) ready() *inspectorMock {
+	i.Response("/v1", "{}")
+	return i
+}
+
+func (i *inspectorMock) notReady(errorCode int) *inspectorMock {
+	i.ErrorResponse("/v1", errorCode)
+	return i
+}
+
+func TestProvisionerIsReady(t *testing.T) {
 
 	cases := []struct {
 		name      string
-		ironic    *testserver.MockServer
-		inspector *testserver.MockServer
+		ironic    *ironicMock
+		inspector *inspectorMock
 
 		expectedIronicCalls    string
 		expectedInspectorCalls string
@@ -50,50 +93,47 @@ func TestProvisionerIsReady(t *testing.T) {
 	}{
 		{
 			name:                   "IsReady",
-			ironic:                 buildServer(t, "ironic", "{}", driverResponse),
-			inspector:              testserver.New(t, "inspector").Response("/v1", "{}"),
+			ironic:                 newIronicMock(t).ready().addDrivers(),
+			inspector:              newInspectorMock(t).ready(),
 			expectedIronicCalls:    "/v1;/v1/drivers;",
 			expectedInspectorCalls: "/v1;",
 			expectedIsReady:        true,
 		},
 		{
 			name:                "NoDriversLoaded",
-			ironic:              buildServer(t, "ironic", "{}", ""),
-			inspector:           testserver.New(t, "inspector"),
+			ironic:              newIronicMock(t).ready(),
+			inspector:           newInspectorMock(t).ready(),
 			expectedIronicCalls: "/v1;/v1/drivers;",
 		},
 		{
 			name:            "IronicDown",
-			inspector:       testserver.New(t, "inspector"),
+			inspector:       newInspectorMock(t).ready(),
 			expectedIsReady: false,
 		},
 		{
 			name:                "InspectorDown",
-			ironic:              buildServer(t, "ironic", "{}", driverResponse),
+			ironic:              newIronicMock(t).ready().addDrivers(),
 			expectedIronicCalls: "/v1;/v1/drivers;",
 			expectedIsReady:     false,
 		},
 		{
-			name: "IronicNotOk",
-			ironic: testserver.New(t, "ironic").
-				ErrorResponse("/v1", http.StatusInternalServerError),
-			inspector:           testserver.New(t, "inspector"),
+			name:                "IronicNotOk",
+			ironic:              newIronicMock(t).notReady(http.StatusInternalServerError),
+			inspector:           newInspectorMock(t).ready(),
 			expectedIsReady:     false,
 			expectedIronicCalls: "/v1;",
 		},
 		{
-			name: "IronicNotOkAndNotExpected",
-			ironic: testserver.New(t, "ironic").
-				ErrorResponse("/v1", http.StatusBadGateway),
-			inspector:           testserver.New(t, "inspector"),
+			name:                "IronicNotOkAndNotExpected",
+			ironic:              newIronicMock(t).notReady(http.StatusBadGateway),
+			inspector:           newInspectorMock(t).ready(),
 			expectedIsReady:     false,
 			expectedIronicCalls: "/v1;",
 		},
 		{
-			name:   "InspectorNotOk",
-			ironic: buildServer(t, "ironic", "{}", driverResponse),
-			inspector: testserver.New(t, "inspector").
-				ErrorResponse("/v1", http.StatusInternalServerError),
+			name:                   "InspectorNotOk",
+			ironic:                 newIronicMock(t).ready().addDrivers(),
+			inspector:              newInspectorMock(t).notReady(http.StatusInternalServerError),
 			expectedIsReady:        false,
 			expectedIronicCalls:    "/v1;/v1/drivers;",
 			expectedInspectorCalls: "/v1;",
@@ -102,20 +142,24 @@ func TestProvisionerIsReady(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			ironicEndpoint := "localhost"
 			if tc.ironic != nil {
 				tc.ironic.Start()
+				ironicEndpoint = tc.ironic.Endpoint()
 				defer tc.ironic.Stop()
 			}
 
+			inspectorEndpoint := "localhost"
 			if tc.inspector != nil {
 				tc.inspector.Start()
+				inspectorEndpoint = tc.inspector.Endpoint()
 				defer tc.inspector.Stop()
 			}
 
 			auth := clients.AuthConfig{Type: clients.NoAuth}
 
 			prov, err := newProvisionerWithSettings(makeHost(), bmc.Credentials{}, nil,
-				tc.ironic.Endpoint(), auth, tc.inspector.Endpoint(), auth,
+				ironicEndpoint, auth, inspectorEndpoint, auth,
 			)
 			if err != nil {
 				t.Fatalf("could not create provisioner: %s", err)

--- a/pkg/provisioner/ironic/testserver/server.go
+++ b/pkg/provisioner/ironic/testserver/server.go
@@ -46,6 +46,13 @@ func (m *MockServer) logRequest(r *http.Request, response string) {
 	m.FullRequests = append(m.FullRequests, r)
 }
 
+func (m *MockServer) handleNoResponse(w http.ResponseWriter, r *http.Request) {
+	if m.errorCode != 0 {
+		http.Error(w, "An error", m.errorCode)
+		return
+	}
+}
+
 // Handler attaches a generic handler function to a request URL pattern
 func (m *MockServer) Handler(pattern string, handlerFunc http.HandlerFunc) *MockServer {
 	m.t.Logf("%s: adding handler for %s", m.name, pattern)
@@ -88,6 +95,10 @@ func (m *MockServer) ErrorResponse(pattern string, errorCode int) *MockServer {
 // Start runs the server
 func (m *MockServer) Start() *MockServer {
 	m.server = httptest.NewServer(m.mux)
+	//catch all handler
+	m.mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		m.logRequest(r, "")
+	})
 	return m
 }
 


### PR DESCRIPTION
- Added fluent interfaces for ironic and inspector mocks
- Added catch all handler for mockServer
- Fixed a problem when ironic or inspector where not defined